### PR TITLE
Don't warn about 'sandbox' when 'bind' is empty

### DIFF
--- a/lib/lmd_common.js
+++ b/lib/lmd_common.js
@@ -1759,13 +1759,22 @@ var analiseModuleContent = function (moduleOptions) {
     moduleDescriptor.code = wrapModule(moduleDescriptor.code, moduleOptions, moduleDescriptor.type);
 
     if (moduleDescriptor.type === "3-party") {
-        if ((moduleOptions.extra_require || moduleOptions.extra_bind) && moduleOptions.is_sandbox) {
+        // Temporary dependencies store for checking number of dependencies
+        // required by 'bind' option.
+        var extraBindRequires = [];
+        // Use dependencies extracting function because it encapsulates
+        // non-trivial algorithm (not only iterating over object properties)
+        // with safety checking.
+        addExtra3partyDepends(moduleOptions.extra_bind, extraBindRequires);
+        if ((moduleOptions.extra_require || extraBindRequires.length > 0) && moduleOptions.is_sandbox) {
             moduleDescriptor.warns
                 .push('Your module "**' + modulePath.join('**", "**') + '**" have to require() some deps, but it sandboxed. ' +
                 'Remove sandbox flag to allow module require().');
         }
         addExtra3partyDepends(moduleOptions.extra_require, moduleDescriptor.depends);
-        addExtra3partyDepends(moduleOptions.extra_bind, moduleDescriptor.depends);
+        for (var i = 0, c = extraBindRequires.length; i < c; i++) {
+            moduleDescriptor.depends.push(extraBindRequires[i]);
+        }
     }
 
     var requireExpressions = findRequireAccesses(ast, moduleDescriptor.type),

--- a/test/build/fixtures/sandbox_option/.lmd/empty_bind_object.lmd.json
+++ b/test/build/fixtures/sandbox_option/.lmd/empty_bind_object.lmd.json
@@ -1,0 +1,10 @@
+{
+  "root": "../js",
+  "modules": {
+    "main": {
+      "path": "main.js",
+      "sandbox": true,
+      "bind": {}
+    }
+  }
+}

--- a/test/build/fixtures/sandbox_option/js/main.js
+++ b/test/build/fixtures/sandbox_option/js/main.js
@@ -1,0 +1,1 @@
+console.log('it works');

--- a/test/build/test.sandbox_option.js
+++ b/test/build/test.sandbox_option.js
@@ -1,0 +1,59 @@
+/*global describe, it, beforeEach, afterEach*/
+/*jshint expr:true*/
+
+var path = require('path'),
+    Stream = require('stream'),
+    vow = require('vow'),
+    expect = require('chai').expect;
+
+// disable colors
+require('colors').mode = 'none';
+
+var Builder = require('../..');
+
+var fixtures = path.join(__dirname, 'fixtures', 'sandbox_option');
+
+function cfgPath(name) {
+    return path.join(fixtures, '.lmd', name + '.lmd.json');
+}
+
+function readStream(stream) {
+    var promise = vow.promise(),
+        body = '';
+
+    if (!stream.readable) {
+        promise.reject(new Error('stream is not readable'));
+        return promise;
+    }
+
+    stream.on('data', function (chunk) {
+        body += chunk;
+    });
+
+    stream.on('end', function () {
+        promise.fulfill(body);
+    });
+
+    stream.on('error', function (error) {
+        promise.reject(error);
+    });
+
+    return promise;
+}
+
+describe('lmd', function() {
+
+    describe('sandbox option', function() {
+        it("shouldn't generate warning if 'bind' object is empty", function (done) {
+            var build = new Builder(cfgPath('empty_bind_object'));
+            var warningRe = /^warn:.+sandbox.*$/m;
+
+            readStream(build.log)
+                .then(function (log) {
+                    expect(log).to.not.match(warningRe);
+                })
+                .then(done, done);
+        });
+    });
+
+});


### PR DESCRIPTION
Empty object as a value of `bind` module option will not produce any `require()` calls, but still is useful for modules exporting its stuff via setting of modules's `this` object properties.

For example, lazy.js [does this](https://github.com/dtao/lazy.js/blob/476ed78f83a33759dbc883327b9d40cc2b390b0c/lazy.js#L5930). In the linked code, `context` is a parameter of IIFE creating whole code scope, so `context` is the `this` passed to IIFE, i.e. object that could be set by LMD's `bind` option.

As a sidenote: lazy.js tries also to use `exports`, but makes one wrong assumption, so it doesn't work with LMD.
